### PR TITLE
Feature/include custom readme dir

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 | Statements                | Branches                | Functions                | Lines                |
 | ------------------------- | ----------------------- | ------------------------ | -------------------- |
-| ![Statements](https://img.shields.io/badge/Coverage-99.43%25-brightgreen.svg) | ![Branches](https://img.shields.io/badge/Coverage-97.06%25-brightgreen.svg) | ![Functions](https://img.shields.io/badge/Coverage-100%25-brightgreen.svg) | ![Lines](https://img.shields.io/badge/Coverage-100%25-brightgreen.svg) |
+| ![Statements](https://img.shields.io/badge/Coverage-100%25-brightgreen.svg) | ![Branches](https://img.shields.io/badge/Coverage-100%25-brightgreen.svg) | ![Functions](https://img.shields.io/badge/Coverage-100%25-brightgreen.svg) | ![Lines](https://img.shields.io/badge/Coverage-100%25-brightgreen.svg) |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 | Statements                | Branches                | Functions                | Lines                |
 | ------------------------- | ----------------------- | ------------------------ | -------------------- |
-| ![Statements](https://img.shields.io/badge/Coverage-100%25-brightgreen.svg) | ![Branches](https://img.shields.io/badge/Coverage-100%25-brightgreen.svg) | ![Functions](https://img.shields.io/badge/Coverage-100%25-brightgreen.svg) | ![Lines](https://img.shields.io/badge/Coverage-100%25-brightgreen.svg) |
+| ![Statements](https://img.shields.io/badge/Coverage-99.43%25-brightgreen.svg) | ![Branches](https://img.shields.io/badge/Coverage-97.06%25-brightgreen.svg) | ![Functions](https://img.shields.io/badge/Coverage-100%25-brightgreen.svg) | ![Lines](https://img.shields.io/badge/Coverage-100%25-brightgreen.svg) |
 
 ---
 
@@ -83,6 +83,12 @@
 
 ```bash
   npm run istanbul-badges-readme --coverageDir="./my-custom-coverage-directory"
+```
+
+- Custom readme directory? Use **--readmeDir** argument:
+
+```bash
+  npm run istanbul-badges-readme --readmeDir="./my-custom-readme-directory"
 ```
 
 - Want it without logging? Try silent mode with **--silent** argument:

--- a/examples/jest-example/package.json
+++ b/examples/jest-example/package.json
@@ -8,7 +8,8 @@
     "cover": "jest --coverage",
     "make-badges": "istanbul-badges-readme",
     "make-badges-silent": "istanbul-badges-readme --silent",
-    "make-badges-custom-dir": "istanbul-badges-readme --coverageDir='./my-custom-coverage'"
+    "make-badges-custom-coverage-dir": "istanbul-badges-readme --coverageDir='./my-custom-coverage'",
+    "make-badges-custom-readme-dir": "istanbul-badges-readme --readmeDir='./my-custom-readme'"
   },
   "husky": {
     "hooks": {

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -84,8 +84,8 @@ export const getNewReadme = (readmeFile: string, coverageFile: string) => (
 };
 
 export const writeNewReadme = (readmePath: string) => (newReadmeData: string): boolean | void => {
+  logInfo('- Writing new readme data...');
   try {
-    console.log('writing file in', readmePath)
     return fs.writeFileSync(readmePath, newReadmeData, 'utf8');
   } catch {
     return false;

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -84,9 +84,8 @@ export const getNewReadme = (readmeFile: string, coverageFile: string) => (
 };
 
 export const writeNewReadme = (readmePath: string) => (newReadmeData: string): boolean | void => {
-  logInfo('- Writing new readme data...');
-
   try {
+    console.log('writing file in', readmePath)
     return fs.writeFileSync(readmePath, newReadmeData, 'utf8');
   } catch {
     return false;

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -1,5 +1,6 @@
 import fs from 'fs';
 import { readmePathConst, coveragePathConst, hashesConst, coverageUrlConst } from './constants';
+import { getCoveragePath, getReadmePath, readFileAsync } from './helpers';
 import { logger } from './logger';
 import { TColors, THashes, TReport } from './types';
 
@@ -92,15 +93,14 @@ export const writeNewReadme = (readmePath: string) => (newReadmeData: string): b
   }
 };
 
-export const editReadme = (): Promise<void> => {
+export const editReadme = async (): Promise<void> => {
   logInfo('Info: 2. Editor process started');
 
-  const readmeFile = fs.readFileSync(readmePathConst, 'utf-8');
-  const coverageFile = fs.readFileSync(coveragePathConst, 'utf8');
+  const readmeFile = await readFileAsync(getReadmePath(readmePathConst), 'utf-8');
+  const coverageFile = await readFileAsync(getCoveragePath(coveragePathConst), 'utf8');
 
-  return Promise.resolve(readmeFile)
-    .then(getReadmeHashes)
+  return Promise.resolve(getReadmeHashes(readmeFile))
     .then(getNewReadme(readmeFile, coverageFile))
-    .then(writeNewReadme(readmePathConst))
+    .then(writeNewReadme(getReadmePath(readmePathConst)))
     .then(() => logInfo('Info: 2. Editor process ended'));
 };

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -4,29 +4,29 @@ import { getArgumentValue } from "./arguments";
 export const getCoveragePath = (path: string): string => {
     let coveragePath: string = path;
     const argPath = getArgumentValue('coverageDir');
-  
+    
     if (argPath) {
-      coveragePath = `${argPath}/coverage-summary.json`;
+        coveragePath = `${argPath}/coverage-summary.json`;
     }
-  
+    
     return coveragePath;
-  };
+};
 
-  export const getReadmePath = (path: string): string => {
+export const getReadmePath = (path: string): string => {
     let readmePath: string = path;
     const argPath = getArgumentValue('readmeDir');
-  
+    
     if (argPath) {
         readmePath = `${argPath}/README.md`;
     }
-  
+
     return readmePath;
   };
 
   export const readFileAsync = async (path: string, encode: string): Promise<string> => {
       return new Promise((resolve, reject) =>{
           fs.readFile(path, encode, (err, data) => {
-              if (err) reject()
+              if (err) reject(`file not found: ${path}`)
               resolve(data)
           } )
       })

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -1,0 +1,33 @@
+import fs from 'fs';
+import { getArgumentValue } from "./arguments";
+
+export const getCoveragePath = (path: string): string => {
+    let coveragePath: string = path;
+    const argPath = getArgumentValue('coverageDir');
+  
+    if (argPath) {
+      coveragePath = `${argPath}/coverage-summary.json`;
+    }
+  
+    return coveragePath;
+  };
+
+  export const getReadmePath = (path: string): string => {
+    let readmePath: string = path;
+    const argPath = getArgumentValue('readmeDir');
+  
+    if (argPath) {
+        readmePath = `${argPath}/README.md`;
+    }
+  
+    return readmePath;
+  };
+
+  export const readFileAsync = async (path: string, encode: string): Promise<string> => {
+      return new Promise((resolve, reject) =>{
+          fs.readFile(path, encode, (err, data) => {
+              if (err) reject()
+              resolve(data)
+          } )
+      })
+  }

--- a/src/validate.ts
+++ b/src/validate.ts
@@ -1,20 +1,9 @@
 import fs from 'fs';
-import { getArgumentValue } from './arguments';
 import { hashesConst, readmePathConst, coveragePathConst } from './constants';
+import { getCoveragePath } from './helpers';
 import { logger } from './logger';
 
 const { logInfo } = logger();
-
-export const getCoveragePath = (path: string): string => {
-  let coveragePath: string = path;
-  const argPath = getArgumentValue('coverageDir');
-
-  if (argPath) {
-    coveragePath = `${argPath}/coverage-summary.json`;
-  }
-
-  return coveragePath;
-};
 
 export const doesReadmeFileExist = (readmePath: string): Promise<boolean | string> => {
   return new Promise((resolve, reject) => {
@@ -49,7 +38,7 @@ export const doesCoverageHashesExist = (coveragePath: string): Promise<boolean |
   });
 };
 
-export const doestReadmeHashExist = (readmePath: string): Promise<boolean | string> => {
+export const doesReadmeHashExist = (readmePath: string): Promise<boolean | string> => {
   return new Promise((resolve, reject) => {
     const readmeFile = fs.readFileSync(readmePath);
 
@@ -76,7 +65,7 @@ export const checkConfig = (): Promise<void> => {
     .then(() => {
       logInfo('- Coverage hashes exist... ✔️.');
     })
-    .then(() => doestReadmeHashExist(readmePathConst))
+    .then(() => doesReadmeHashExist(readmePathConst))
     .then(() => {
       logInfo('- Readme hashes exist... ✔️.');
     })

--- a/tests/helpers.spec.ts
+++ b/tests/helpers.spec.ts
@@ -1,0 +1,25 @@
+import { getCoveragePath, getReadmePath, readFileAsync } from "../src/helpers";
+
+describe('test helpers file', () => {
+  it('should getCoveragePath from arguments', () => {
+    process.argv.push('--coverageDir=my-custom-dir');
+    const args = getCoveragePath('coverageDir');
+
+    expect(args).toEqual('my-custom-dir/coverage-summary.json');
+
+    process.argv.pop();
+  });
+
+  it('should getReadmePath from arguments', () => {
+    process.argv.push('--readmeDir=my-custom-dir');
+    const args = getReadmePath('readmeDir');
+
+    expect(args).toEqual('my-custom-dir/README.md');
+
+    process.argv.pop();
+  });
+
+  it ('should fail to read an async file', async () => {
+    await readFileAsync('./foo/bar.biz', 'utf-8').catch(e => expect(e).toBeUndefined())
+  })
+})

--- a/tests/helpers.spec.ts
+++ b/tests/helpers.spec.ts
@@ -20,6 +20,6 @@ describe('test helpers file', () => {
   });
 
   it ('should fail to read an async file', async () => {
-    await readFileAsync('./foo/bar.biz', 'utf-8').catch(e => expect(e).toBeUndefined())
+    await readFileAsync('./foo/bar.biz', 'utf-8').catch(e => expect(e).toEqual('file not found: ./foo/bar.biz'))
   })
 })

--- a/tests/validate.spec.ts
+++ b/tests/validate.spec.ts
@@ -2,23 +2,13 @@ import path from 'path';
 import {
   doesReadmeFileExist,
   doesCoverageFileExist,
-  getCoveragePath,
   doesCoverageHashesExist,
-  doestReadmeHashExist,
+  doesReadmeHashExist,
 } from '../src/validate';
 
 describe('Tests validate file', () => {
   afterEach(() => {
     jest.clearAllMocks();
-  });
-
-  it('should getCoveragePath from arguments', () => {
-    process.argv.push('--coverageDir=my-custom-dir');
-    const args = getCoveragePath('coverageDir');
-
-    expect(args).toEqual('my-custom-dir/coverage-summary.json');
-
-    process.argv.pop();
   });
 
   it('should throw when doesReadmeFileExist does not find file', async () => {
@@ -43,10 +33,10 @@ describe('Tests validate file', () => {
     });
   });
 
-  it("should throw when doestReadmeHashExist can't find a hash", async () => {
+  it("should throw when doesReadmeHashExist can't find a hash", async () => {
     const fakeReadmeFile = path.join(__dirname, '../tests/mocks/fakeReadmeFile.md');
 
-    doestReadmeHashExist(fakeReadmeFile).catch((error) => {
+    doesReadmeHashExist(fakeReadmeFile).catch((error) => {
       expect(error).toEqual('Readme does not contain the needed hashes');
     });
   });


### PR DESCRIPTION
I've included a new argument to allow one to point to a different path for the `README.md` file.

Ex:
```sh
📦  Project folder
 ┣ 📂 src
 ┃	┣ 📜 package.json
 ┃	┗ 📂 coverage
 ┣ 📂 devops 
 ┣ 📂 docs
 ┣ 📂 terraform
 ┗ 📜 README.md
```

Within this structure above, I run my tests inside the `src` folder, but I want to write my coverage badges on my `README.md` file in the root of the project.