### PR TITLE
fix: check for read & write permissions on README file

### DIFF
--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -31,3 +31,11 @@ export const readFileAsync = async (path: string, encode: BufferEncoding): Promi
     });
   });
 };
+
+/**
+ * Asserts that the given `error` was created by Node internals.
+ * @param error The error object.
+ * @returns `true` if given error object is a NodeJS error.
+ */
+export const isNodeErrnoError = (error: unknown): error is NodeJS.ErrnoException =>
+  error instanceof Error && 'code' in error;

--- a/tests/validate.spec.ts
+++ b/tests/validate.spec.ts
@@ -1,6 +1,7 @@
+import fs from 'fs';
 import path from 'path';
 import {
-  doesReadmeFileExist,
+  doesReadmeFileExistWithRightPermissions,
   doesCoverageFileExist,
   doesCoverageHashesExist,
   doesReadmeHashExist,
@@ -11,10 +12,73 @@ describe('Tests validate file', () => {
     jest.clearAllMocks();
   });
 
-  it('should throw when doesReadmeFileExist does not find file', async () => {
-    await doesReadmeFileExist('fake-path').catch((error) => {
-      expect(error).toEqual('Readme file does not exist');
+  it('should throw when doesReadmeFileExistWithRightPermissions does not find file', async () => {
+    const fsSpy = jest.spyOn(fs, 'accessSync').mockImplementation(() => {
+      const error: NodeJS.ErrnoException = new Error();
+      error.code = 'ENOENT';
+      throw error;
     });
+
+    await expect(
+      //
+      doesReadmeFileExistWithRightPermissions('fake-path'),
+    ).rejects.toEqual('Readme file does not exist');
+
+    expect(fsSpy).toHaveBeenNthCalledWith(1, 'fake-path', fs.constants.R_OK | fs.constants.W_OK);
+  });
+
+  it('should throw when doesReadmeFileExistWithRightPermissions does find file the file but it does not have read & write permissions', async () => {
+    const fsMock = jest.spyOn(fs, 'accessSync').mockImplementation(() => {
+      const error: NodeJS.ErrnoException = new Error();
+      error.code = 'EACCES';
+      throw error;
+    });
+
+    await expect(
+      //
+      doesReadmeFileExistWithRightPermissions('fake-path'),
+    ).rejects.toEqual('Readme file does not have read and write permissions');
+
+    expect(fsMock).toHaveBeenNthCalledWith(1, 'fake-path', fs.constants.R_OK | fs.constants.W_OK);
+  });
+
+  test('doesReadmeFileExistWithRightPermissions should rethrow any other fs error there is not related with file permissions nor find issues', async () => {
+    const fsSpy = jest.spyOn(fs, 'accessSync').mockImplementation(() => {
+      const error: NodeJS.ErrnoException = new Error('something');
+      error.code = 'EBUSY';
+      throw error;
+    });
+
+    await expect(
+      //
+      doesReadmeFileExistWithRightPermissions('fake-path'),
+    ).rejects.toEqual('something');
+
+    expect(fsSpy).toHaveBeenNthCalledWith(1, 'fake-path', fs.constants.R_OK | fs.constants.W_OK);
+  });
+
+  test('doesReadmeFileExistWithRightPermissions should rethrow any other error there is not related with fs module', async () => {
+    const fsSpy = jest.spyOn(fs, 'accessSync');
+
+    fsSpy.mockImplementation(() => {
+      throw new Error('something');
+    });
+
+    await expect(
+      //
+      doesReadmeFileExistWithRightPermissions('fake-path'),
+    ).rejects.toEqual('something');
+
+    fsSpy.mockImplementation(() => {
+      throw new Error();
+    });
+
+    await expect(
+      //
+      doesReadmeFileExistWithRightPermissions('fake-path'),
+    ).rejects.toEqual('Something went wrong');
+
+    expect(fsSpy).toHaveBeenNthCalledWith(2, 'fake-path', fs.constants.R_OK | fs.constants.W_OK);
   });
 
   it('should throw when doesCoverageFileExist does not find file', async () => {

--- a/tests/validate.spec.ts
+++ b/tests/validate.spec.ts
@@ -12,7 +12,7 @@ describe('Tests validate file', () => {
   });
 
   it('should throw when doesReadmeFileExist does not find file', async () => {
-    doesReadmeFileExist('fake-path').catch((error) => {
+    await doesReadmeFileExist('fake-path').catch((error) => {
       expect(error).toEqual('Readme file does not exist');
     });
   });
@@ -20,7 +20,7 @@ describe('Tests validate file', () => {
   it('should throw when doesCoverageFileExist does not find file', async () => {
     const fakePath = 'fake-path';
 
-    doesCoverageFileExist('fake-path').catch((error) => {
+    await doesCoverageFileExist('fake-path').catch((error) => {
       expect(error).toEqual(`Coverage file does not exist in ${fakePath}`);
     });
   });
@@ -28,7 +28,7 @@ describe('Tests validate file', () => {
   it("should throw when doesCoverageHashesExist can't find a hash", async () => {
     const fakeJsonPath = path.join(__dirname, '../tests/mocks/fakeBadCoverage.json');
 
-    doesCoverageHashesExist(fakeJsonPath).catch((error) => {
+    await doesCoverageHashesExist(fakeJsonPath).catch((error) => {
       expect(error).toEqual('Coverage file does contain the needed hashes');
     });
   });
@@ -36,7 +36,7 @@ describe('Tests validate file', () => {
   it("should throw when doesReadmeHashExist can't find a hash", async () => {
     const fakeReadmeFile = path.join(__dirname, '../tests/mocks/fakeReadmeFile.md');
 
-    doesReadmeHashExist(fakeReadmeFile).catch((error) => {
+    await doesReadmeHashExist(fakeReadmeFile).catch((error) => {
       expect(error).toEqual('Readme does not contain the needed hashes');
     });
   });


### PR DESCRIPTION
Closes #58

---

For whatever reason doing:

```js
try {
  fs.accessSync('fake-path', fs.constants.R_OK | fs.constants.W_OK)
} catch (err) {
  console.log(err instanceof Error) // always: false
}
```

in some **spec file**, `err` above won't be an instance of `Error`. This is why I've use `mockImplementation` on `fs.accessSync` method. Otherwise, it never enter on the IF statement of L19 of `src/validate.ts`

I didn't like that approach as it doesn't use the real `fs` module, and makes the test suite pretty coupled with the implementation. But didn't find another way to write that.
