### PR TITLE
feat: add flag `--exitCode` to exit on validation errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,12 @@
   npm run istanbul-badges-readme --logo="jest"
 ```
 
+- To exit with **1** code on validation errors (eg: _README doesn't exists_, or _coverage directory doesn't exists_) or on editing errors (eg: cannot write the README due to lack of permissions). The default exit code is **0**.
+
+```bash
+  npm run istanbul-badges-readme --exitCode
+```
+
 ---
 
 ## Usage as a part of your githooks

--- a/src/validate.ts
+++ b/src/validate.ts
@@ -1,4 +1,5 @@
 import fs from 'fs';
+import { getArgumentValue } from './arguments';
 import { hashesConst, readmePathConst, coveragePathConst } from './constants';
 import { getCoveragePath, getReadmePath, isNodeErrnoError } from './helpers';
 import { logger } from './logger';
@@ -62,6 +63,12 @@ export const doesReadmeHashExist = (readmePath: string): Promise<boolean | strin
   });
 };
 
+export const getExitCodeOnValidationError = (): number => {
+  const exitCodeArg = getArgumentValue('exitCode');
+  const enableExitCode = exitCodeArg === '' || exitCodeArg === 'true';
+  return enableExitCode ? 1 : 0;
+};
+
 export const checkConfig = (): Promise<void> => {
   logInfo('Info: 1. Config check process started');
 
@@ -81,5 +88,11 @@ export const checkConfig = (): Promise<void> => {
     .then(() => {
       logInfo('- Readme hashes exist... ✔️.');
     })
-    .then(() => logInfo('Info: 1. Config check process ended'));
+    .then(() => logInfo('Info: 1. Config check process ended'))
+    .catch((err) => {
+      process.exitCode = getExitCodeOnValidationError();
+      // Re-throwing the error since we catch it in this scope just to defined
+      // the right process exit code:
+      throw err;
+    });
 };

--- a/tests/validate.spec.ts
+++ b/tests/validate.spec.ts
@@ -5,6 +5,7 @@ import {
   doesCoverageFileExist,
   doesCoverageHashesExist,
   doesReadmeHashExist,
+  getExitCodeOnValidationError,
 } from '../src/validate';
 
 describe('Tests validate file', () => {
@@ -102,6 +103,23 @@ describe('Tests validate file', () => {
 
     await doesReadmeHashExist(fakeReadmeFile).catch((error) => {
       expect(error).toEqual('Readme does not contain the needed hashes');
+    });
+  });
+
+  test.each([
+    [0, ' is not supplied', undefined],
+    [1, ' is supplied', ''],
+    [0, '=false', 'false'],
+    [1, '=true', 'true'],
+  ])('getExitCodeOnValidationError should return %d when --exitCode%s', (expectedExitCode, _, exitCodeArgValue) => {
+    if (exitCodeArgValue !== undefined) {
+      process.argv.push(`--exitCode=${exitCodeArgValue}`);
+    }
+
+    expect(getExitCodeOnValidationError()).toBe(expectedExitCode);
+
+    afterEach(() => {
+      process.argv.pop();
     });
   });
 });


### PR DESCRIPTION
closes #57
