### PR TITLE
Badge Color Config

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@
 ```
 
 #### Configure Badge Color
-- You can configure the color threshold of the badges by passing the `--colors` parameter. If you want red badges for a code coverage below 50% and yellow badges for a coverage below 60%, you'd do this:
+- You can configure the color threshold of the badges by passing the `--colors` argument. If you want red badges for a code coverage below 50% and yellow badges for a coverage below 60%, you'd do this:
 ```bash
   npm run istanbul-badges-readme --colors=red:50,yellow:60
 ```

--- a/README.md
+++ b/README.md
@@ -135,6 +135,9 @@
   npm run istanbul-badges-readme --logo="jest"
 ```
 
+#### Configure Badge Color
+
+
 #### Exit code
 
 - To exit with **1** code on validation errors (eg.: _README doesn't exist_, or _coverage directory doesn't exist_) or on editing errors (eg.: cannot write to README due to lack of permissions). The default exit code is **0**. Set a different one by using **--exitCode** argument.

--- a/README.md
+++ b/README.md
@@ -136,6 +136,10 @@
 ```
 
 #### Configure Badge Color
+- You can configure the color threshold of the badges by passing the `--colors` parameter. If you want red badges for a code coverage below 50% and yellow badges for a coverage below 60%, you'd do this:
+```bash
+  npm run istanbul-badges-readme --colors=red:50,yellow:60
+```
 
 
 #### Exit code

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -49,3 +49,32 @@ export const getExitCodeOnError = (): number | undefined => {
 
   return argExitCode && !isNaN(argExitCode) ? argExitCode : undefined;
 };
+
+/**
+ * Parses a string representing colors and their corresponding numeric values into an object.
+ * The input string should be formatted as "color:value", with multiple color-value pairs separated by commas.
+ * This function specifically expects "red", "yellow", and "brightgreen" as the only valid colors in the string.
+ *
+ * @param {string} colorsString - The string representation of colors and their values to parse.
+ * @returns {{ red: number; yellow: number; brightgreen: number }} An object with keys "red", "yellow", and "brightgreen",
+ *          each mapped to their numeric value as specified in the input string.
+ */
+export const parseColorConfig = (colorsString: string): {
+  red: number;
+  yellow: number;
+} => {
+  if (!colorsString) {
+    return { red: 80, yellow: 90 };
+  }
+
+  return colorsString.split(',').reduce((acc, colorPair) => {
+    const [color, value] = colorPair.split(':');
+    if (color === 'red' || color === 'yellow') {
+      acc[color] = parseInt(value, 10);
+    }
+    return acc;
+  }, {} as { red: number; yellow: number; });
+};
+
+
+


### PR DESCRIPTION
I need to change the thresholds of the badge color. I've added an argument to do so.

#### Configure Badge Color
- You can configure the color threshold of the badges by passing the `--colors` argument. If you want red badges for a code coverage below 50% and yellow badges for a coverage below 60%, you'd do this:
```bash
  npm run istanbul-badges-readme --colors=red:50,yellow:60
```